### PR TITLE
guardar vacío cuando un evento no tiene place

### DIFF
--- a/src/js/modules/calendar.js
+++ b/src/js/modules/calendar.js
@@ -145,7 +145,7 @@ function renderMonthlyCalendars (monthlyCalendar) {
                             data-day="${eventDay.format('dddd DD')}"
                             data-hour="${eventDay.format('HH:mm')}"
                             data-event-name="${event.eventName}"
-                            data-place="${event.place}"
+                            data-place="${event.place || ''}"
                             data-event-link="${event.eventLink}"
                             data-color="${event.color}"
                             style="background-color: ${event.color};">


### PR DESCRIPTION
Se muestra undefined cuando un evento viene sin atributo **place**

![selection_017](https://cloud.githubusercontent.com/assets/161916/26507007/dd51f446-4224-11e7-9871-eba829e1dea6.png)

