### PR TITLE
Arregla la hora de los eventos en el calendario

### DIFF
--- a/components/Calendar/CalendarPage.jsx
+++ b/components/Calendar/CalendarPage.jsx
@@ -71,7 +71,9 @@ class CalendarPage extends Component {
     }
   };
 
-  getFormattedEventHour = date => format(new Date(date).setUTCMinutes(180), 'HH:mm');
+  addMinutes = (date, minutes) => new Date(date.getTime() + minutes * 60000);
+
+  getFormattedEventHour = date => format(this.addMinutes(new Date(date), 180), 'HH:mm');
 
   hideModal = () => {
     this.setState({ showModal: false }, () => this.toggleOverflow(false));


### PR DESCRIPTION
La hora de los eventos de la API del calendar viene en UTC, pero con el valor de horas y minutos correspondiente a Argentina. El código intentaba agregar 3 horas (180 minutos) para contrarrestar el offset de Argentina, pero en realidad estaba seteando los minutos.

Se agrega una función para agregar minutos a un Date object.