### PR TITLE
Make YouTube videos responsive work

### DIFF
--- a/pages/_app.css
+++ b/pages/_app.css
@@ -71,11 +71,11 @@ body {
 }
 
 .video-wrapper iframe {
-  height: 100%;
+  height: 100% !important;
   left: 0;
   position: absolute;
   top: 0;
-  width: 100%;
+  width: 100% !important;
 }
 
 @media screen and (min-width: 60em) {


### PR DESCRIPTION
Right now the react-youtube component is adding a `width` and `height` with fixed values and that makes the videos not responsive.

This adds `!important` to those iframe width and height to overwrite the tag attributes.